### PR TITLE
Emit 'update' when orderbook updated and 'reset' after reset

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ class OrderBook extends EventEmitter {
     // but in our case it's much easier to reset orderbook and
     // implement all accumulated updates again.
     // Poloniex's frontend works the same way "reset and reload".
-    if (!this._resetInProgress && _.size(this.buffer) > 25) {
+    if (!this._resetInProgress && _.size(this.buffer) > 0) {
       debug(`Buffer is too fat: ${_.size(this.buffer)}`);
       this.resetOrderBook();
     }

--- a/index.js
+++ b/index.js
@@ -80,6 +80,7 @@ class OrderBook extends EventEmitter {
         }
         debug(`Reset orderbook: ${this.pair}`);
         delete this._resetInProgress;
+        this.emit('reset');
       });
 
     return this._resetInProgress;
@@ -94,7 +95,6 @@ class OrderBook extends EventEmitter {
    */
   _onOrderTrade(res, {seq}) {
     debug(`Push event came: ${seq}`);
-    this.emit('update', res);
     for (const order of res) {
       // ignore history events
       if (order.type == "newTrade") {
@@ -112,6 +112,7 @@ class OrderBook extends EventEmitter {
     // increment orderbook sequentially.
     // order by order according to its `seq`
     this._processBuffer();
+    this.emit('update', res);
   }
 
   /**


### PR DESCRIPTION
The 'update' event should be emitted only when the book is in sync with the server. An user may process the records pushed, but he will usually do that only for newTrade events but use just updated orderbook as is (after update).

Also the reset event is necessary for the same reason: to notify user about complete orderbook change.